### PR TITLE
Fix typo in gerrors.go

### DIFF
--- a/internal/gerrors/gerrors.go
+++ b/internal/gerrors/gerrors.go
@@ -36,7 +36,7 @@ func (e *errorWithStack) Unwrap() error {
 	return e.err
 }
 
-// GoString implemenrts fmt.GoStringer.
+// GoString implements fmt.GoStringer.
 func (e *errorWithStack) GoString() string {
 	return fmt.Sprintf("&gerrors.errorWithStack{err: %#v, stack: %#v}", e.err, e.stack)
 }


### PR DESCRIPTION
* 90e65c4 Fix typo in gerrors.go
